### PR TITLE
Show share file thumbnail when image file is uploaded

### DIFF
--- a/lib/publish.rb
+++ b/lib/publish.rb
@@ -66,7 +66,7 @@ module SlackWormhole
       }
 
       web.files_sharedPublicURL(payload)
-      data.text += "\n" + data.files[0].permalink_public
+      data.text += "\n" + data.files[0].permalink
       post_message(data)
     end
 


### PR DESCRIPTION
permalink_public is not contain file extension.
This PR change permalink_public to permalink that includes file
extension link.

closed: #13