### PR TITLE
Change url of share file to thumbnail url

### DIFF
--- a/lib/publish.rb
+++ b/lib/publish.rb
@@ -66,7 +66,12 @@ module SlackWormhole
       }
 
       res = web.files_sharedPublicURL(payload)
-      data.text += "\n" + res['file']['permalink_public']
+      if res['file']['thumb_360'] != ""
+        url = res['file']['thumb_360']
+      else
+        url = res['file']['permalink_public']
+      end
+      data.text += "\n" + url
       post_message(data)
     end
 


### PR DESCRIPTION
permalink_publicのものではサムネイルが表示されないため、
thumbnailのURLを表示するように変更。
thumbnailのURLにアクセスすると元ファイルに転送されることを確認済み.