### PR TITLE
Fix removing reaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ bundle install --path vendor/bundle
 |originalTs|string||true|
 |timestamp|string||true|
 |user|string||true|
+|reaction|string||true|
 
 ### Environment Variables
 

--- a/lib/publish.rb
+++ b/lib/publish.rb
@@ -103,9 +103,10 @@ module SlackWormhole
           timestamp: data.ts,
           thread_ts: data.item.ts,
           room: channel(data.item.channel).name,
+          userid: data.user,
           username: name,
           icon_url: icon,
-          text: ":#{data.reaction}:",
+          reaction: data.reaction,
         }
 
         q = query.where('timestamp', '=', payload[:thread_ts]).limit(1)
@@ -123,7 +124,9 @@ module SlackWormhole
       payload = {
         action: 'reaction_remove',
         room: channel(data.item.channel).name,
+        userid: data.user,
         username: name,
+        reaction: data.reaction,
         timestamp: data.item.ts,
       }
 


### PR DESCRIPTION
- DatastoreのEntityに `reaction` のプロパティを追加
- 転送されたリアクションを一意に定めるためにリアクションの情報を追加
- timestamp, userid, reactionから削除対象を一意に特定し削除に変更

closed: #12