### PR TITLE
Apply message to use data of base64 encoding

### DIFF
--- a/lib/publish.rb
+++ b/lib/publish.rb
@@ -172,7 +172,9 @@ module SlackWormhole
 
     def self.publish(payload)
       begin
-        topic.publish(payload)
+        json = JSON.dump(payload)
+        data = Base64.strict_encode64(json)
+        topic.publish(data)
         logger.info("Message has been published - Action[#{payload[:action]}]")
       rescue Google::Cloud::InvalidArgumentError => e
         logger.error(e)

--- a/lib/subscribe.rb
+++ b/lib/subscribe.rb
@@ -13,7 +13,8 @@ module SlackWormhole
       subscription = pubsub.subscription(subscription_name)
       subscriber = subscription.listen do |received_message|
         received_message.acknowledge!
-        data =  received_message.grpc.message.attributes
+        json = Base64.strict_decode64(received_message.grpc.message.data)
+        data = JSON.load(json)
 
         unless allowed_channel?(data['room'])
           logger.info("\"#{data['room']}\" is not allowed to receive channel !")

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -1,6 +1,8 @@
 require "google/cloud/datastore"
 require 'google/cloud/pubsub'
 require 'slack-ruby-client'
+require 'base64'
+require 'json'
 
 Slack::Web::Client.configure do |config|
   config.token = ENV['SLACK_API_USER_TOKEN']


### PR DESCRIPTION
やったこと
- PubSubの `attribute` 利用から `data` に変更
- Publish側でhashのデータをjson文字列にしてBase64エンコード
- Subscribe側で受け取ったデータをBase64でデコードしJSONにパース