### PR TITLE
Set unfurl_links true on postMessage

### DIFF
--- a/lib/subscribe.rb
+++ b/lib/subscribe.rb
@@ -29,6 +29,7 @@ module SlackWormhole
             icon_url: data['icon_url'],
             text: data['text'],
             as_user: false,
+            unfurl_links: true,
           }
           message = post_message(payload)
           save_message(subscription_name, message, data['timestamp'])


### PR DESCRIPTION
~permalink_publicの代わりにurl_downloadを使うことで、画像のプレビューなどができるようにする
Ref: https://api.slack.com/methods/files.sharedPublicURL
(url_downloadはファイル直へのpublic url)~

unfurl_links: trueをpayloadに含めることで、botからの投稿でもリンクが展開されるようになるはず
https://api.slack.com/methods/chat.postMessage