### PR TITLE
Resolve error of ClientAlreadyStartedError

### DIFF
--- a/lib/publish.rb
+++ b/lib/publish.rb
@@ -204,6 +204,7 @@ module SlackWormhole
 
     private
     def self.rtm_start!
+      rtm.stop! if rtm.started?
       rtm.start!
     rescue Interrupt => e
       logger.error(e)


### PR DESCRIPTION
Socketが閉じられていない状態でstart!するとでるエラーに対応
```
message: "E, [2019-11-11T04:37:09.763919 #1] ERROR -- : Slack::RealTime::Client::ClientAlreadyStartedError (Slack::RealTime::Client::ClientAlreadyStartedError)" 
```